### PR TITLE
Drupal content hook

### DIFF
--- a/src/hooks/useDrupalPage/index.jsx
+++ b/src/hooks/useDrupalPage/index.jsx
@@ -8,6 +8,7 @@ async function getPage(rootURL, uuid, entityType, bundle) {
   });
 }
 
+// @TODO move comments to its own hook.
 async function getComments(rootURL, uuid) {
   return await axios.get(`${rootURL}jsonapi/comment/comment?include=entity_id&filter[entity_id.id][value]=${uuid}`)
   .then((res) => {

--- a/src/hooks/useDrupalPage/index.jsx
+++ b/src/hooks/useDrupalPage/index.jsx
@@ -1,0 +1,42 @@
+import axios from 'axios';
+import React, {useState, useEffect} from 'react';
+
+async function getPage(rootURL, uuid, entityType, bundle) {
+  return await axios.get(`${rootURL}jsonapi/${entityType}/${bundle}/${uuid}`)
+  .then((res) => {
+    return res.data.data
+  });
+}
+
+async function getComments(rootURL, uuid) {
+  return await axios.get(`${rootURL}jsonapi/comment/comment?include=entity_id&filter[entity_id.id][value]=${uuid}`)
+  .then((res) => {
+    return res.data.data
+  });
+}
+
+export const useDrupalEntity = (rootURL, uuid, entityType, bundle, options) => {
+  const {includeComments} = options;
+  const [entity, setEntity] = useState({});
+  const [comments, setComments] = useState([]);
+  useEffect(() => {
+    async function fetchPageData() {
+      const data = await getPage(rootURL, uuid, entityType, bundle);
+      setEntity(data);
+    }
+    fetchPageData();
+  }, [])
+  useEffect(() => {
+    async function fetchCommentData() {
+      const commentData = await getComments(rootURL, uuid);
+      setComments(commentData);
+    }
+    if (includeComments) {
+      fetchCommentData();
+    }
+  }, [includeComments])
+  return {
+    entity,
+    comments
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 export { default as useDatastore } from './hooks/useDatastore'
 export { default as useDatastoreSQL } from './hooks/useDatastoreSQL';
 export { default as useMetastoreDataset } from './hooks/useMetastoreDataset'
+export { useDrupalEntity } from './hooks/useDrupalPage'
 
 // REACT COMPONENTS and OUT OF BOX STUFF
 export { default as Resource } from './Resource'


### PR DESCRIPTION
This is a new hook to use jsonAPI to fetch Drupal content. 

Below is an example template for how this can be used:
```import React from "react";
import config from "../../assets/config";
import { useDrupalEntity } from "../../services/drupalContent";

const DrupalPage = ({ path, rootURL, uuid, entityType, bundle, options }) => {
  const {entity, comments} = useDrupalEntity(rootURL, uuid, entityType, bundle, options);

  const bodyContent = Object.keys(entity).length ? (
    <div className={`dc-page ${config.container}`}>
      <h1>{entity.attributes.title}</h1>
      <div className="dc-page-content" dangerouslySetInnerHTML={{ __html: entity.attributes.body.processed }} />
    </div>
  ) : '';
  const commentContent = comments.map((comment) => (
    <div className='comment'>
      <h3>{comment.attributes.subject}</h3>
      <div className="dc-comment-content" dangerouslySetInnerHTML={{ __html: comment.attributes.comment_body.processed }} />
    </div>
  ))
    return (
      <>
      {bodyContent}
      {commentContent.length ? (
        <div>
          <h2>Comments</h2>
          {commentContent}
        </div>
      ) : ''}
      </>
  );
}
export default DrupalPage;
```