### PR TITLE
Add QS library and dataset search url functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "immutability-helper": "^3.0.2",
     "lodash": "^4.17.21",
     "prop-types": "^15.6.2",
+    "qs": "^6.10.1",
     "query-string": "^6.14.0",
     "react-aria-modal": "^4.0.0",
     "react-dnd": "^10.0.2",
@@ -101,9 +102,9 @@
     "jest": "^24.9.0",
     "node-sass": "^4.13.1",
     "prettier": "^1.16.0",
+    "react-dom": "^16.13.1",
     "react-scripts": "^4.0.3",
     "react-test-renderer": "^16.9.0",
-    "react-dom": "^16.13.1",
     "sass-loader": "^7.1.0",
     "url-loader": "^1.1.2"
   },

--- a/src/hooks/useSearchAPI/helpers.js
+++ b/src/hooks/useSearchAPI/helpers.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import queryString from 'query-string';
+import qs from 'qs';
 
 export function separateFacets(facets) {
   let facetObj = {};
@@ -34,6 +35,19 @@ export function updateSelectedFacetObject(currentFacet, selectedFacets) {
   return newFacetList;
 }
 
+export const transformUrlParamsToSearchObject = (searchParams, facetList) => {
+  const params = qs.parse(searchParams, { ignoreQueryPrefix: true })
+  const selectedFacets = {}
+  facetList.forEach((facet) => {
+    selectedFacets[facet] = params[facet] ? params[facet] : [];
+  })
+  return {
+    selectedFacets: selectedFacets,
+    fulltext: params.fulltext,
+    sort: params.sort
+  }
+}
+
 export async function fetchDatasets(rootUrl, options) {
   const { fulltext, selectedFacets, sort, sortOrder, page, pageSize } = options;
   
@@ -46,4 +60,15 @@ export async function fetchDatasets(rootUrl, options) {
     ['page-size']: pageSize !== 10 ? pageSize : '',
   }
   return await axios.get(`${rootUrl}/search/?${queryString.stringify(params, {arrayFormat: 'comma', skipEmptyString: true })}`)
+}
+
+export function stringifySearchParams(selectedFacets, fulltext, sort) {
+  let newParams = {...selectedFacets}
+  if(fulltext) {
+    newParams.fulltext = fulltext;
+  }
+  if(sort) {
+    newParams.sort = sort;
+  }
+  return qs.stringify(newParams, {addQueryPrefix: true, encode: false, arrayFormat: 'brackets'})
 }

--- a/src/hooks/useSearchAPI/helpers.js
+++ b/src/hooks/useSearchAPI/helpers.js
@@ -35,7 +35,7 @@ export function updateSelectedFacetObject(currentFacet, selectedFacets) {
   return newFacetList;
 }
 
-export const transformUrlParamsToSearchObject = (searchParams, facetList) => {
+export function transformUrlParamsToSearchObject(searchParams, facetList) {
   const params = qs.parse(searchParams, { ignoreQueryPrefix: true })
   const selectedFacets = {}
   facetList.forEach((facet) => {

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,6 @@ export { transformTableFilterToQueryCondition, transformTableFilterToSQLConditio
 
 // HELPERS
 export { buildPageArray } from './hooks/usePagination/buildPageArray';
-export { separateFacets } from './hooks/useSearchAPI/helpers';
+export { separateFacets, transformUrlParamsToSearchObject, stringifySearchParams, fetchDatasets } from './hooks/useSearchAPI/helpers';
 
 export { transformURLtoDatastoreQuery } from './Resource/urlQuery';

--- a/yarn.lock
+++ b/yarn.lock
@@ -12253,6 +12253,13 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.10.1:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
+  integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@^6.9.4:
   version "6.9.6"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"


### PR DESCRIPTION
Add QS library and dataset search url functions to transform url search params to an object for the dataset search hook and transform an object back into a search url. This doesn't update the url in any way as that will be left for the specific application to handle. 