### PR TITLE
Bug fix: Add catch method to metadatastore hook/fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/data-catalog-services",
-  "version": "1.0.0-alpha.15",
+  "version": "1.0.0-alpha.16",
   "description": "Functions and React components to connect to the DKAN api.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/hooks/useMetastoreDataset/index.jsx
+++ b/src/hooks/useMetastoreDataset/index.jsx
@@ -10,7 +10,8 @@ const useMetastoreDataset = (datasetId, rootAPIUrl, additionalParams={}) => {
   useEffect(() => {
     async function fetchData() {
       return axios.get(`${rootUrl}/metastore/schemas/dataset/items/${id}?show-reference-ids${additionalParamsString}`)
-        .then((res) => setDataset(res.data));
+        .then((res) => setDataset(res.data))
+        .catch((error) => setDataset({error: error}));
     }
     fetchData();
   }, [id, rootUrl]);


### PR DESCRIPTION
This replaces some code that was accidentally removed adding an error to the response of the metastore hook. The removal broke 404s on the dataset pages when nothing was returned from the api endpoint. 