### PR TITLE
Update datastore fetch to build columns from schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/data-catalog-services",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Functions and React components to connect to the DKAN api.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/hooks/useDatastore/fetch.js
+++ b/src/hooks/useDatastore/fetch.js
@@ -28,10 +28,11 @@ export async function fetchDataFromQuery(id, rootUrl, options, additionalParams)
   })
   .then((res) => {
     const { data } = res;
+    const propertyKeys = data.schema[id] && data.schema[id].fields ? Object.keys(data.schema[id].fields) : [];
     setValues(data.results),
     setCount(data.count)
     if(data.results.length) {
-      setColumns(prepareColumns ? prepareColumns(Object.keys(data.results[0])) : Object.keys(data.results[0]))
+      setColumns(prepareColumns ? prepareColumns(propertyKeys) : propertyKeys)
     }
     setSchema(data.schema)
     if(typeof setLoading === 'function') {


### PR DESCRIPTION
When fetching new data from the datastore, build the columns using the schema instead of first row of data. On pages sending initial conditions, the columns would return empty if no data was found. Since the schema is now returned even if there are no results, we can use it to always build the column array. 