### PR TITLE
Switch fetch conditional for columns to schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/data-catalog-services",
-  "version": "1.1.0",
+  "version": "1.2.0-alpha.1",
   "description": "Functions and React components to connect to the DKAN api.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/data-catalog-services",
-  "version": "1.2.0-alpha.1",
+  "version": "1.2.0",
   "description": "Functions and React components to connect to the DKAN api.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/hooks/useDatastore/fetch.js
+++ b/src/hooks/useDatastore/fetch.js
@@ -31,7 +31,7 @@ export async function fetchDataFromQuery(id, rootUrl, options, additionalParams)
     const propertyKeys = data.schema[id] && data.schema[id].fields ? Object.keys(data.schema[id].fields) : [];
     setValues(data.results),
     setCount(data.count)
-    if(data.results.length) {
+    if(propertyKeys.length) {
       setColumns(prepareColumns ? prepareColumns(propertyKeys) : propertyKeys)
     }
     setSchema(data.schema)


### PR DESCRIPTION
Switch conditional to set and return columns from datastore hook if schema exists not if there are results. For filtered views, we may not get any results, and this will allow for the columns to appear with a no results message. 