### PR TITLE
Check if id is an array and update datastore api correctly

### DIFF
--- a/src/hooks/useDatastore/fetch.js
+++ b/src/hooks/useDatastore/fetch.js
@@ -1,18 +1,40 @@
-import axios from 'axios';
-import qs from 'qs'
+import axios from "axios";
+import qs from "qs";
 
-export async function fetchDataFromQuery(id, rootUrl, options, additionalParams) {
-  const { keys, limit, offset, conditions, sort, prepareColumns, properties, setValues, setCount, setColumns, setLoading, setSchema } = options;
-  if(!id) {
+export async function fetchDataFromQuery(
+  id,
+  rootUrl,
+  options,
+  additionalParams
+) {
+  const {
+    keys,
+    limit,
+    offset,
+    conditions,
+    sort,
+    prepareColumns,
+    properties,
+    setValues,
+    setCount,
+    setColumns,
+    setLoading,
+    setSchema,
+  } = options;
+  if (!id) {
     // TODO: Throw error
     return false;
   }
-  if(typeof setLoading === 'function') {
+  if (typeof setLoading === "function") {
     setLoading(true);
   }
+
+  let url = Array.isArray(id)
+    ? `${rootUrl}/datastore/query/${id[0]}/${id[1]}`
+    : `${rootUrl}/datastore/query/${id}`;
   return await axios({
-    method: 'GET',
-    url: `${rootUrl}/datastore/query/${id}`,
+    method: "GET",
+    url: url,
     params: {
       keys: keys,
       limit: limit,
@@ -23,21 +45,22 @@ export async function fetchDataFromQuery(id, rootUrl, options, additionalParams)
       ...additionalParams,
     },
     paramsSerializer: (params) => {
-      return qs.stringify(params)
-    }
-  })
-  .then((res) => {
+      return qs.stringify(params);
+    },
+  }).then((res) => {
     const { data } = res;
-    const propertyKeys = data.schema[id] && data.schema[id].fields ? Object.keys(data.schema[id].fields) : [];
-    setValues(data.results),
-    setCount(data.count)
-    if(propertyKeys.length) {
-      setColumns(prepareColumns ? prepareColumns(propertyKeys) : propertyKeys)
+    const propertyKeys =
+      data.schema[id] && data.schema[id].fields
+        ? Object.keys(data.schema[id].fields)
+        : [];
+    setValues(data.results), setCount(data.count);
+    if (propertyKeys.length) {
+      setColumns(prepareColumns ? prepareColumns(propertyKeys) : propertyKeys);
     }
-    setSchema(data.schema)
-    if(typeof setLoading === 'function') {
+    setSchema(data.schema);
+    if (typeof setLoading === "function") {
       setLoading(false);
     }
     return data;
-  })
+  });
 }


### PR DESCRIPTION
The datastore endpoint can be used in two ways:
`/query/distribution_id` or `/query/dataset_id/distribution_index`

The easiest way to add this and be backwards compatible would be allow for the id parameter to use either a string for the the distribution id or an array of `[dataset_id, distribution_index]`. Then in the fetch I can just check to see if the parameter is an array and adjust the url value accordingly. 